### PR TITLE
Fix script crash and main menu layout overflow.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,16 +18,16 @@
         
         <!-- Schermata Menu Principale -->
         <div id="main-menu" class="text-center">
-            <h1 id="main-title" class="text-4xl font-bold mb-8 text-[#c8a27c]">Gilda dei Taglialegna</h1>
-            <div class="space-y-4 max-w-sm mx-auto">
-                <button id="new-game-button" class="game-button w-full bg-green-800 hover:bg-green-700 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-green-900">NUOVA PARTITA</button>
-                <button id="load-game-button" class="game-button w-full bg-blue-700 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-blue-900">CARICA PARTITA</button>
-                <button id="import-game-button" class="game-button w-full bg-purple-700 hover:bg-purple-600 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-purple-900">IMPORTA PARTITA</button>
-                <button id="hof-button" class="game-button w-full bg-yellow-700 hover:bg-yellow-600 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-yellow-900">HALL OF FAME</button>
-                <button id="credits-button" class="game-button w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-gray-800">CREDITS</button>
-                <button id="manual-button" class="game-button w-full bg-gray-600 hover:bg-gray-500 text-white font-bold py-3 px-4 rounded-lg shadow-lg border-b-4 border-gray-800">MANUALE DI GIOCO</button>
+            <h1 id="main-title" class="text-4xl font-bold mb-6 text-[#c8a27c]">Gilda dei Taglialegna</h1>
+            <div class="space-y-3 max-w-sm mx-auto">
+                <button id="new-game-button" class="game-button w-full bg-green-800 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-green-900">NUOVA PARTITA</button>
+                <button id="load-game-button" class="game-button w-full bg-blue-700 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-blue-900">CARICA PARTITA</button>
+                <button id="import-game-button" class="game-button w-full bg-purple-700 hover:bg-purple-600 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-purple-900">IMPORTA PARTITA</button>
+                <button id="hof-button" class="game-button w-full bg-yellow-700 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-yellow-900">HALL OF FAME</button>
+                <button id="credits-button" class="game-button w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-gray-800">CREDITS</button>
+                <button id="manual-button" class="game-button w-full bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-gray-800">MANUALE DI GIOCO</button>
             </div>
-            <div class="mt-8 max-w-sm mx-auto">
+            <div class="mt-6 max-w-sm mx-auto">
                 <label for="volume-slider" class="block mb-2 text-sm font-medium">Volume</label>
                 <input id="volume-slider" type="range" min="0" max="1" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
             </div>

--- a/script.js
+++ b/script.js
@@ -25,7 +25,6 @@ const importGameButton = document.getElementById('import-game-button');
 const manualButton = document.getElementById('manual-button');
 const creditsButton = document.getElementById('credits-button');
 const hofButton = document.getElementById('hof-button');
-const exitButton = document.getElementById('exit-button');
 const volumeSlider = document.getElementById('volume-slider');
 const backgroundMusic = document.getElementById('background-music');
 
@@ -194,7 +193,7 @@ function startChapter(chapterId) {
     if (!gameState.player) {
          gameState.player = JSON.parse(JSON.stringify(initialPlayerState));
     }
-    
+
     gameState.player.metrics = {};
     for (const metricKey in chapter.metrics) {
         gameState.player.metrics[metricKey] = 5;
@@ -203,7 +202,7 @@ function startChapter(chapterId) {
     gameState.currentChapterId = chapterId;
     gameState.scenarios = [...chapter.scenarios].sort(() => Math.random() - 0.5);
     gameState.currentScenarioIndex = -1;
-    
+
     mainTitle.textContent = chapter.title;
     showScreen(gameScreen);
     nextScenario();
@@ -250,7 +249,7 @@ function nextScenario() {
 function selectChoice(choice) {
     const scenario = gameState.scenarios[gameState.currentScenarioIndex];
     if (!scenario) return;
-    
+
     gameState.player.score += 10;
 
     const effects = scenario.choices[choice].effects;
@@ -312,14 +311,13 @@ function init() {
     manualButton.addEventListener('click', () => showScreen(manualScreen));
     creditsButton.addEventListener('click', displayCredits);
     hofButton.addEventListener('click', displayHallOfFame);
-    exitButton.addEventListener('click', () => window.close());
 
     // Listener Schermata di Gioco
     yesButton.addEventListener('click', () => selectChoice('yes'));
     noButton.addEventListener('click', () => selectChoice('no'));
     downloadGameButton.addEventListener('click', downloadSaveFile);
     returnToMenuButton.addEventListener('click', () => showScreen(mainMenu));
-    
+
     // Listener Schermata Finale
     endScreenMenuButton.addEventListener('click', () => showScreen(mainMenu));
     continueButton.addEventListener('click', (e) => {
@@ -333,7 +331,7 @@ function init() {
     manualBackButton.addEventListener('click', () => showScreen(mainMenu));
     creditsBackButton.addEventListener('click', () => showScreen(mainMenu));
     hofBackButton.addEventListener('click', () => showScreen(mainMenu));
-    
+
     // Listener Audio
     const savedVolume = localStorage.getItem('lumberjackVolume');
     volumeSlider.value = savedVolume ? savedVolume : 0.5;
@@ -358,7 +356,7 @@ function init() {
             }
         }
     });
-    
+
     showScreen(mainMenu);
 }
 


### PR DESCRIPTION
The `script.js` file was crashing during initialization because it was trying to add an event listener to a non-existent element with the ID 'exit-button'. This prevented any of the subsequent event listeners from being attached, causing all buttons to be non-functional. The references to 'exit-button' have been removed.

The main menu layout was overflowing on smaller viewports due to large vertical margins and padding. The Tailwind CSS classes in `index.html` have been adjusted to create a more compact layout that fits within the screen without requiring a scrollbar.