### PR TITLE
Feat: Increase Hall of Fame size and player name length

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
             <h2 class="text-2xl font-bold mb-6 text-[#c8a27c]">Crea il tuo Personaggio</h2>
             <div>
                 <label for="player-name-input" class="block mb-2 text-sm font-medium text-left">Nome del Giocatore</label>
-                <input type="text" id="player-name-input" class="bg-gray-700 border border-gray-600 text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" placeholder="Massimo 3 lettere (es. GDL)" maxlength="3" required>
+                <input type="text" id="player-name-input" class="bg-gray-700 border border-gray-600 text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" placeholder="Massimo 20 lettere" maxlength="20" required>
             </div>
             <button id="start-game-button" class="mt-6 game-button w-full bg-green-800 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-lg border-b-4 border-green-900">Inizia l'Avventura</button>
         </div>

--- a/script.js
+++ b/script.js
@@ -76,17 +76,17 @@ function getHighScores() {
 
 function saveHighScores(scores) {
     scores.sort((a, b) => b.score - a.score);
-    const topScores = scores.slice(0, 5);
+    const topScores = scores.slice(0, 10);
     localStorage.setItem(HOF_KEY, JSON.stringify(topScores));
 }
 
 function checkAndAddHighScore(score) {
     const highScores = getHighScores();
-    const lowestHighScore = highScores.length < 5 ? 0 : highScores[4].score;
+    const lowestHighScore = highScores.length < 10 ? 0 : highScores[9].score;
 
     if (score > lowestHighScore) {
         const name = gameState.player.name || "AAA";
-        const newScore = { name: name.slice(0, 3).toUpperCase(), score: score };
+        const newScore = { name: name, score: score };
         highScores.push(newScore);
         saveHighScores(highScores);
     }
@@ -310,7 +310,7 @@ function init() {
     });
 
     startGameButton.addEventListener('click', () => {
-        let playerName = playerNameInput.value.trim().toUpperCase();
+        let playerName = playerNameInput.value.trim();
         if (!playerName) {
             playerName = "AAA";
         }


### PR DESCRIPTION
This commit implements your requested changes to the player name and Hall of Fame systems.

- The maximum player name length has been increased from 3 to 20 characters in the new game modal.
- The Hall of Fame has been expanded to store and display the top 10 high scores, increased from 5.
- The logic for processing player names for the Hall of Fame has been updated to allow for longer, case-sensitive names.