### PR TITLE
Fix: Implement cumulative scoring and correct Hall of Fame logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -192,10 +192,12 @@ function startChapter(chapterId) {
         return;
     }
 
-    // Preserve player name but reset other stats
+    // Preserve player name and score, but reset metrics and flags for the new chapter.
     const playerName = gameState.player.name;
-    gameState.player = JSON.parse(JSON.stringify(initialPlayerState));
+    const playerScore = gameState.player.score;
+    gameState.player = JSON.parse(JSON.stringify(initialPlayerState)); // Reset metrics and flags
     gameState.player.name = playerName;
+    gameState.player.score = playerScore;
 
     gameState.player.metrics = {};
     for (const metricKey in chapter.metrics) {
@@ -272,7 +274,6 @@ function selectChoice(choice) {
 
 function endGame(reason, state) {
     const finalScoreValue = gameState.player.score;
-    checkAndAddHighScore(finalScoreValue); // Check high score before deleting save
     deleteSave();
     showScreen(endScreen);
 
@@ -296,6 +297,8 @@ function endGame(reason, state) {
         endScreenMenuButton.classList.add('hidden');
         continueButton.dataset.nextChapter = finalEnding.nextChapter;
     } else {
+        // This is a true ending, not a chapter transition. Check for high score.
+        checkAndAddHighScore(finalScoreValue);
         continueButton.classList.add('hidden');
         endScreenMenuButton.classList.remove('hidden');
     }
@@ -314,9 +317,9 @@ function init() {
         if (!playerName) {
             playerName = "AAA";
         }
-        gameState = {
-            player: JSON.parse(JSON.stringify(initialPlayerState))
-        };
+        // Reset gameState for a new game
+        gameState = {};
+        gameState.player = JSON.parse(JSON.stringify(initialPlayerState));
         gameState.player.name = playerName;
         startChapter(STARTING_CHAPTER);
     });


### PR DESCRIPTION
This commit addresses a major logical flaw in how player scores were handled between chapters.

- The player's score is now cumulative and persists across chapters. The `startChapter` function has been modified to preserve the score while resetting chapter-specific metrics and flags.
- The Hall of Fame logic has been corrected. The game now only checks for and submits a high score when a true "game over" ending is reached, not at the end of every chapter. This prevents a single playthrough from generating multiple high scores.